### PR TITLE
Clarify usage instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We provided a fully working example.
 ```bash
 git clone https://github.com/serpapi/serpapi-java.git
 cd serpapi-java/demo
-make run api_key=<your private key>
+make all API_KEY=<your private key>
 ```
 Note: You need an account with SerpApi to obtain this key from: https://serpapi.com/dashboard
 


### PR DESCRIPTION
This includes the two small clarifying changes to the Readme suggested in https://github.com/serpapi/serpapi-java/issues/1:

1. Capitalize the reference to `API_KEY` 
2. Suggest using `make all` instead of `make run`

Closes https://github.com/serpapi/serpapi-java/issues/1